### PR TITLE
Caitlyn/issues

### DIFF
--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		2E45B2422B4E5CE100FB83B7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2E45B2412B4E5CE100FB83B7 /* GoogleService-Info.plist */; };
 		2E45B2452B4F632700FB83B7 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2E45B2442B4F632700FB83B7 /* FirebaseAnalytics */; };
 		2E45B2472B4F643500FB83B7 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E45B2462B4F643500FB83B7 /* AnalyticsManager.swift */; };
-		2E4F06DC2B4B48DC008905C8 /* UpliftAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 2E4F06DB2B4B48DC008905C8 /* UpliftAPI */; };
 		2E5726C72B4A63AE00D3DB36 /* ShimmerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5726C62B4A63AE00D3DB36 /* ShimmerModifier.swift */; };
 		2E6785B92B3A425E00DD3ADA /* GymDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6785B82B3A425E00DD3ADA /* GymDetailView.swift */; };
 		2E6785BC2B3A48D700DD3ADA /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = 2E6785BB2B3A48D700DD3ADA /* WrappingHStack */; };
@@ -71,6 +70,7 @@
 		2EE5F3E42B12EDB6008E0299 /* ApolloAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 2EE5F3E32B12EDB6008E0299 /* ApolloAPI */; };
 		2EF1A2582B129EEB007A299F /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF1A2572B129EEB007A299F /* Network.swift */; };
 		842FB0CCD71C3202DE5836F1 /* Pods_Uplift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E86AC23F1B9AFB11552390BF /* Pods_Uplift.framework */; };
+		89CFD8472B605785004E8065 /* UpliftAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 89CFD8462B605785004E8065 /* UpliftAPI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -164,7 +164,7 @@
 				842FB0CCD71C3202DE5836F1 /* Pods_Uplift.framework in Frameworks */,
 				2EE5F3E22B12EDB6008E0299 /* Apollo in Frameworks */,
 				2E6785BC2B3A48D700DD3ADA /* WrappingHStack in Frameworks */,
-				2E4F06DC2B4B48DC008905C8 /* UpliftAPI in Frameworks */,
+				89CFD8472B605785004E8065 /* UpliftAPI in Frameworks */,
 				2E090ECB2B12FF5900BAE982 /* UpliftAPI in Frameworks */,
 				2E45B2452B4F632700FB83B7 /* FirebaseAnalytics in Frameworks */,
 				2E39D82F2B3BCBA400AD238B /* UpliftAPI in Frameworks */,
@@ -467,9 +467,9 @@
 				2E6785BB2B3A48D700DD3ADA /* WrappingHStack */,
 				2E39D82E2B3BCBA400AD238B /* UpliftAPI */,
 				2EC3EE652B3C000E00E927BF /* Kingfisher */,
-				2E4F06DB2B4B48DC008905C8 /* UpliftAPI */,
 				2E45B23F2B4E361100FB83B7 /* FirebaseCrashlytics */,
 				2E45B2442B4F632700FB83B7 /* FirebaseAnalytics */,
+				89CFD8462B605785004E8065 /* UpliftAPI */,
 			);
 			productName = Uplift;
 			productReference = 2E8FE38C2B1278B700B3DC6A /* Uplift.app */;
@@ -508,8 +508,8 @@
 				2EE5F3E02B12EDB6008E0299 /* XCRemoteSwiftPackageReference "apollo-ios" */,
 				2E6785BA2B3A48D700DD3ADA /* XCRemoteSwiftPackageReference "WrappingHStack" */,
 				2EC3EE642B3C000E00E927BF /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				2E4F06DA2B4B48DC008905C8 /* XCLocalSwiftPackageReference "UpliftAPI" */,
 				2E45B23E2B4E361100FB83B7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				89CFD8452B605785004E8065 /* XCLocalSwiftPackageReference "UpliftAPI" */,
 			);
 			productRefGroup = 2E8FE38D2B1278B700B3DC6A /* Products */;
 			projectDirPath = "";
@@ -987,7 +987,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		2E4F06DA2B4B48DC008905C8 /* XCLocalSwiftPackageReference "UpliftAPI" */ = {
+		89CFD8452B605785004E8065 /* XCLocalSwiftPackageReference "UpliftAPI" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = UpliftAPI;
 		};
@@ -1051,10 +1051,6 @@
 			package = 2E45B23E2B4E361100FB83B7 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
 		};
-		2E4F06DB2B4B48DC008905C8 /* UpliftAPI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = UpliftAPI;
-		};
 		2E6785BB2B3A48D700DD3ADA /* WrappingHStack */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2E6785BA2B3A48D700DD3ADA /* XCRemoteSwiftPackageReference "WrappingHStack" */;
@@ -1074,6 +1070,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2EE5F3E02B12EDB6008E0299 /* XCRemoteSwiftPackageReference "apollo-ios" */;
 			productName = ApolloAPI;
+		};
+		89CFD8462B605785004E8065 /* UpliftAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = UpliftAPI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Uplift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Uplift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "7e28eb75e9970edaba346a3c1eab1f8fc479a04d",
-        "version" : "1.7.1"
+        "revision" : "ff54632b8740ecfb858bae4630d822e615c7ef1c",
+        "version" : "1.8.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "5746b2d35c91c50581590ed97abe4c06b5037274",
-        "version" : "10.18.0"
+        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
+        "version" : "10.18.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "c60c958e707c50a9cf8bcb7cfd7d51c566d726c5",
-        "version" : "10.19.1"
+        "revision" : "b880ec8ec927a838c51c12862c6222c30d7097d7",
+        "version" : "10.20.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "6b332152355c372ace9966d8ee76ed191f97025e",
-        "version" : "10.17.0"
+        "revision" : "ceec9f28dea12b7cf3dabf18b5ed7621c88fd4aa",
+        "version" : "10.20.0"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "add0a87ec4e31e2ca2a0b2085f0559201e4f5918",
-        "version" : "7.10.1"
+        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
+        "version" : "7.10.2"
       }
     },
     {

--- a/Uplift/Services/AnalyticsManager.swift
+++ b/Uplift/Services/AnalyticsManager.swift
@@ -56,6 +56,9 @@ enum UpliftEvent: String {
     /// Taps on a the button to toggle capacities into view on the home page.
     case tapCapacityToggle = "tap_capacity_toggle"
 
+    /// Taps on a gym capacity circle under toggle capacities on the home page.
+    case tapCapacityCircle = "tap_capacity_circle"
+
     /// Taps on a gym cell on the home page.
     case tapGymCell = "tap_gym_cell"
 

--- a/Uplift/ViewModels/FitnessCenterViewModel.swift
+++ b/Uplift/ViewModels/FitnessCenterViewModel.swift
@@ -26,7 +26,7 @@ extension FitnessCenterView {
         func fetchFitnessCenterHours(for fc: Facility) {
             fitnessCenterHours = []
             for day in DayOfWeek.sortedDaysOfWeek() {
-                let hours = fc.hours.getHoursInDayOfWeek(dayOfWeek: day)
+                let hours = fc.hours.getHoursInDayOfWeek(dayOfWeek: day).sorted()
 
                 if hours.isEmpty {
                     fitnessCenterHours.append("Closed")

--- a/Uplift/ViewModels/GymDetailViewModel.swift
+++ b/Uplift/ViewModels/GymDetailViewModel.swift
@@ -43,7 +43,7 @@ extension GymDetailView {
         func fetchBuildingHours(for gym: Gym) {
             buildingHours = []
             for day in DayOfWeek.sortedDaysOfWeek() {
-                let hours = gym.hours.getHoursInDayOfWeek(dayOfWeek: day)
+                let hours = gym.hours.getHoursInDayOfWeek(dayOfWeek: day).sorted()
 
                 if hours.isEmpty {
                     buildingHours.append("Closed")

--- a/Uplift/ViewModels/HomeViewModel.swift
+++ b/Uplift/ViewModels/HomeViewModel.swift
@@ -63,6 +63,23 @@ extension HomeView {
                               let rhsStatus = $1.status else { return false }
                         return lhsStatus < rhsStatus
                     }
+                    .sorted {
+                        ($0.fitnessCenters.contains { fc in
+                            switch fc.status {
+                            case .open:
+                                return true
+                            default:
+                                return false
+                            }
+                        } ? 0 : 1) < ($1.fitnessCenters.contains { fc in
+                            switch fc.status {
+                            case .open:
+                                return true
+                            default:
+                                return false
+                            }
+                        } ? 0 : 1)
+                    }
             }
             .store(in: &queryBag)
         }
@@ -118,6 +135,13 @@ extension HomeView {
 
             if openCount == 0 { return 0.0 }
             return val / Double(openCount)
+        }
+
+        /// Returns the gym given the facility.
+        func gymWithFacility(_ facility: Facility?) -> Gym? {
+            gyms?.first(
+                where: { $0.fitnessCenters.contains { $0 == facility } }
+            )
         }
 
     }

--- a/Uplift/Views/Home/FitnessCenterView.swift
+++ b/Uplift/Views/Home/FitnessCenterView.swift
@@ -100,7 +100,7 @@ struct FitnessCenterView: View {
                 }
             }
         }
-        .frame(width: 230)
+        .frame(width: 232)
         .foregroundStyle(Constants.Colors.black)
     }
 
@@ -116,6 +116,7 @@ struct FitnessCenterView: View {
             HStack(spacing: 8) {
                 Text(viewModel.fitnessCenterHours.first ?? "")
                     .font(Constants.Fonts.f2)
+                    .multilineTextAlignment(.leading)
 
                 Triangle()
                     .fill(Constants.Colors.black)

--- a/Uplift/Views/HomeView.swift
+++ b/Uplift/Views/HomeView.swift
@@ -71,18 +71,108 @@ struct HomeView: View {
             if let gyms = viewModel.gyms {
                 VStack(spacing: 12) {
                     HStack(spacing: 12) {
-                        capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.hnhFitness))
+                        NavigationLink {
+                            if let helenNewmanGym = viewModel.gymWithFacility(
+                                gyms.facilityWithName(name: Constants.FacilityNames.hnhFitness)
+                            ) {
+                                GymDetailView(gym: helenNewmanGym)
+                            }
+                        } label: {
+                            capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.hnhFitness))
+                        }
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                AnalyticsManager.shared.log(
+                                    UpliftEvent.tapCapacityCircle.toEvent(
+                                        type: .facility,
+                                        value: Constants.FacilityNames.hnhFitness
+                                    )
+                                )
+                            }
+                        )
 
-                        capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.teagleUp))
+                        NavigationLink {
+                            if let teagleGym = viewModel.gymWithFacility(
+                                gyms.facilityWithName(name: Constants.FacilityNames.teagleUp)
+                            ) {
+                                GymDetailView(gym: teagleGym)
+                            }
+                        } label: {
+                            capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.teagleUp))
+                        }
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                AnalyticsManager.shared.log(
+                                    UpliftEvent.tapCapacityCircle.toEvent(
+                                        type: .facility,
+                                        value: Constants.FacilityNames.teagleUp
+                                    )
+                                )
+                            }
+                        )
                     }
 
                     HStack(spacing: 12) {
-                        capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.teagleDown))
+                        NavigationLink {
+                            if let teagleGym = viewModel.gymWithFacility(
+                                gyms.facilityWithName(name: Constants.FacilityNames.teagleDown)
+                            ) {
+                                GymDetailView(gym: teagleGym)
+                            }
+                        } label: {
+                            capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.teagleDown))
+                        }
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                AnalyticsManager.shared.log(
+                                    UpliftEvent.tapCapacityCircle.toEvent(
+                                        type: .facility,
+                                        value: Constants.FacilityNames.teagleDown
+                                    )
+                                )
+                            }
+                        )
 
-                        capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.noyesFitness))
+                        NavigationLink {
+                            if let noyesGym = viewModel.gymWithFacility(
+                                gyms.facilityWithName(name: Constants.FacilityNames.noyesFitness)
+                            ) {
+                                GymDetailView(gym: noyesGym)
+                            }
+                        } label: {
+                            capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.noyesFitness))
+                        }
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                AnalyticsManager.shared.log(
+                                    UpliftEvent.tapCapacityCircle.toEvent(
+                                        type: .facility,
+                                        value: Constants.FacilityNames.noyesFitness
+                                    )
+                                )
+                            }
+                        )
                     }
 
-                    capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.morrFitness))
+                    NavigationLink {
+                        if let morrisonGym = viewModel.gymWithFacility(
+                            gyms.facilityWithName(name: Constants.FacilityNames.morrFitness)
+                        ) {
+                            GymDetailView(gym: morrisonGym)
+                        }
+                    } label: {
+                        capacityCircle(facility: gyms.facilityWithName(name: Constants.FacilityNames.morrFitness))
+                    }
+                    .simultaneousGesture(
+                        TapGesture().onEnded {
+                            AnalyticsManager.shared.log(
+                                UpliftEvent.tapCapacityCircle.toEvent(
+                                    type: .facility,
+                                    value: Constants.FacilityNames.morrFitness
+                                )
+                            )
+                        }
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Overview

Fixed issues #22, #23, #29, and #30.

## Changes Made

- Added sorting to gym cards so that it sorts by open fitness centers before sorting by building hours.
    - All fitness centers must close before sorting by building hours.
    - Open Fitness Centers < Open Gym Buildings < Closest Location
- Tapping on a fitness center capacity circle under the capacities toggle now pushes the corresponding gym’s detailed view.
    - Added `tap_capacity_circle` under Analytics to track these interactions.
- Sorted the fitness center hours in the gym’s detailed view so that earlier hours are displayed on top.
- Fixed the width of fitness center hours and left aligned the button text with the rest of the hours.

## Screenshots

<details>

<summary>Fitness Center Hours</summary>

<img src="https://github.com/cuappdev/uplift-ios-swiftui/assets/118781810/9b2f4d62-e223-489e-b4e3-f64f387a7f5c" width="400">

</details>