### PR TITLE
Implemented stretchy header

### DIFF
--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		2EE5F3E42B12EDB6008E0299 /* ApolloAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 2EE5F3E32B12EDB6008E0299 /* ApolloAPI */; };
 		2EF1A2582B129EEB007A299F /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF1A2572B129EEB007A299F /* Network.swift */; };
 		842FB0CCD71C3202DE5836F1 /* Pods_Uplift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E86AC23F1B9AFB11552390BF /* Pods_Uplift.framework */; };
+		89ECDA892B79885C0006A160 /* StretchyModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89ECDA882B79885C0006A160 /* StretchyModifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,6 +146,7 @@
 		2EE5F3C92B12E34D008E0299 /* Apollo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Apollo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2EF1A2572B129EEB007A299F /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		61B508C772C15943F0FDB2E8 /* Pods-Uplift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Uplift.debug.xcconfig"; path = "Target Support Files/Pods-Uplift/Pods-Uplift.debug.xcconfig"; sourceTree = "<group>"; };
+		89ECDA882B79885C0006A160 /* StretchyModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StretchyModifier.swift; sourceTree = "<group>"; };
 		D6EB08EC41E957E55D918532 /* Pods-Uplift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Uplift.release.xcconfig"; path = "Target Support Files/Pods-Uplift/Pods-Uplift.release.xcconfig"; sourceTree = "<group>"; };
 		E86AC23F1B9AFB11552390BF /* Pods_Uplift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Uplift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -333,6 +335,7 @@
 				2E6785BD2B3A513000DD3ADA /* SemiCircleShape.swift */,
 				2E15F5012B396EC500414BEC /* ShadowModifier.swift */,
 				2E5726C62B4A63AE00D3DB36 /* ShimmerModifier.swift */,
+				89ECDA882B79885C0006A160 /* StretchyModifier.swift */,
 				2E15F5112B3A3D0000414BEC /* TriangleShape.swift */,
 			);
 			path = Custom;
@@ -670,6 +673,7 @@
 				2E090EC52B12EF2600BAE982 /* Publishers.swift in Sources */,
 				2E39D8222B3B631200AD238B /* DividerLine.swift in Sources */,
 				2E15F5062B39F81B00414BEC /* MainView.swift in Sources */,
+				89ECDA892B79885C0006A160 /* StretchyModifier.swift in Sources */,
 				2E39D82A2B3B9F3D00AD238B /* FacilityExpandedView.swift in Sources */,
 				2E39D82C2B3BB35000AD238B /* FacilityExpandedViewModel.swift in Sources */,
 				2E3D6C202B1285D200B51BB2 /* UpliftEnvironment.swift in Sources */,

--- a/Uplift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Uplift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "ff54632b8740ecfb858bae4630d822e615c7ef1c",
-        "version" : "1.8.0"
+        "revision" : "7e28eb75e9970edaba346a3c1eab1f8fc479a04d",
+        "version" : "1.7.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
-        "version" : "10.18.1"
+        "revision" : "5746b2d35c91c50581590ed97abe4c06b5037274",
+        "version" : "10.18.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "b880ec8ec927a838c51c12862c6222c30d7097d7",
-        "version" : "10.20.0"
+        "revision" : "c60c958e707c50a9cf8bcb7cfd7d51c566d726c5",
+        "version" : "10.19.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ceec9f28dea12b7cf3dabf18b5ed7621c88fd4aa",
-        "version" : "10.20.0"
+        "revision" : "6b332152355c372ace9966d8ee76ed191f97025e",
+        "version" : "10.17.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
-        "version" : "7.10.2"
+        "revision" : "add0a87ec4e31e2ca2a0b2085f0559201e4f5918",
+        "version" : "7.10.1"
       }
     },
     {

--- a/Uplift/Utils/Custom/StretchyModifier.swift
+++ b/Uplift/Utils/Custom/StretchyModifier.swift
@@ -1,0 +1,37 @@
+//
+//  StretchyHeaderModifier.swift
+//  Uplift
+//
+//  Created by Caitlyn Jin on 2/11/24.
+//  Copyright © 2024 Cornell AppDev. All rights reserved.
+//
+
+import SwiftUI
+
+/// A view modifier that applies a stretchy effect to the header image.
+struct StretchyModifier: ViewModifier {
+
+    var geometryProxy: GeometryProxy
+
+    func body(content: Content) -> some View {
+        let minY = geometryProxy.frame(in: .global).minY
+        let originY = geometryProxy.frame(in: .global).origin.y
+        let height = geometryProxy.size.height
+
+        content
+            .frame(height: minY > 0 ? height + originY : height)
+            .clipped()
+            .offset(y: minY > 0 ? -minY : 0)
+    }
+
+}
+
+extension View {
+
+    @ViewBuilder
+    func stretchy(_ gp: GeometryProxy) -> some View {
+        self
+            .modifier(StretchyModifier(geometryProxy: gp))
+    }
+
+}

--- a/Uplift/Views/Home/GymDetailView.swift
+++ b/Uplift/Views/Home/GymDetailView.swift
@@ -81,14 +81,16 @@ struct GymDetailView: View {
     @MainActor
     private var heroSection: some View {
         ZStack(alignment: .center) {
-            KFImage(gym.imageUrl)
-                .placeholder {
-                    Constants.Colors.gray01
-                }
-                .resizable()
-                .scaledToFill()
-                .frame(height: 330)
-                .clipped()
+            GeometryReader { geometryProxy in
+                KFImage(gym.imageUrl)
+                    .placeholder {
+                        Constants.Colors.gray01
+                    }
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .stretchy(geometryProxy)
+            }
+            .frame(height: 330)
 
             if viewModel.showHours {
                 hoursView


### PR DESCRIPTION
## Overview

Implemented a stretchy header effect to the `GymDetailView` header image.

## Changes Made

- Created a custom `StretchyModifier` view modifier that applies a stretchy effect to the header image.
- Modified `GymDetailView` to contain the header image in a `GeometryReader` and used a geometry proxy to calculate its bounds.
    - Used the stretchy view modifier on the header image.

## Related PRs or Issues

- #8  

## Screenshots (optional)

<!-- use the following for videos -->
<details>
  <summary>Stretchy Header</summary>
  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  <tr>
    <td><video src="https://github.com/cuappdev/uplift-ios-swiftui/assets/118781810/798be44d-197d-4a0c-ae12-0a642173cb83" type="video/mp4"></td>
    <td><video src="https://github.com/cuappdev/uplift-ios-swiftui/assets/118781810/a9fefc2a-0145-45b0-b10e-15609e1a907f" type="video/mp4"></td>
  </tr>
 </table>
</details>