### PR TITLE
Tab bar styling adjustment

### DIFF
--- a/Uplift/Views/Home/GymDetailView.swift
+++ b/Uplift/Views/Home/GymDetailView.swift
@@ -59,6 +59,7 @@ struct GymDetailView: View {
             heroSection
             !gym.amenities.isEmpty ? amenitiesSection : nil
             slidingTabBar(gymName: viewModel.determineGymNameEnum(gym: gym))
+            DividerLine()
 
             Group {
                 if viewModel.selectedTab == .fitnessCenter {

--- a/Uplift/Views/Supporting/SlidingTabBarView.swift
+++ b/Uplift/Views/Supporting/SlidingTabBarView.swift
@@ -32,8 +32,8 @@ struct SlidingTabBarView<T: Hashable>: View {
     private func tab(for item: Item) -> some View {
         VStack(alignment: .center, spacing: 16) {
             Text(item.title)
-                .font(selectedTab == item.tab ? config.selectedFont : config.unselectedFont)
-                .foregroundStyle(config.color)
+                .font(config.font)
+                .foregroundStyle(selectedTab == item.tab ? config.selectedColor : config.unselectedColor)
                 .padding(.top)
 
             if selectedTab == item.tab {
@@ -68,10 +68,10 @@ extension SlidingTabBarView {
 
     /// Configuration for a tab bar.
     struct TabBarConfig {
-        var color: Color = Constants.Colors.black
-        var selectedFont: Font = Constants.Fonts.labelBold
+        var font: Font = Constants.Fonts.labelBold
+        var selectedColor: Color = Constants.Colors.black
         var selectedUnderlineColor: Color = Constants.Colors.yellow
-        var unselectedFont: Font = Constants.Fonts.labelMedium
+        var unselectedColor: Color = Constants.Colors.gray04
         var unselectedUnderlineColor: Color = Constants.Colors.white
     }
 


### PR DESCRIPTION
## Overview

Minor adjustment with the tab bar design for the gym detail view.

## Changes Made

- Modified the `SlidingTabBarView` config:
    - Added bold attribute to both the selected and unselected tabs.
    - Set lighter text color for the unselected tab.
- Added a divider line at the bottom of the tab bar view.

## Screenshots

<!-- use the following for images -->
<details>
  <summary>Tab Bar</summary>
  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  <tr>
    <td><img src="https://github.com/cuappdev/uplift-ios-swiftui/assets/118781810/8a673ed0-af2e-4478-a25a-393c5118a101" width="300px" height="auto"></td>
    <td><img src="https://github.com/cuappdev/uplift-ios-swiftui/assets/118781810/00fa851c-db38-4823-ad6e-abc407defe46" width="300px" height="auto"></td>
  </tr>
 </table>
</details>