### PR TITLE
Fix Xcode Cloud issues with Apollo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,9 @@ fi
 
 ```
 
-5. Download and install [Apollo](https://www.apollographql.com/docs/devtools/cli/) and GraphQL with the following commands. You will need to have Node’s NPM installed on your device.
-
-   - `npm install -g apollo`
-   - `npm install -g graphql`
-
-6. Select the `Uplift` schema to use our development server and `Uplift-Prod` to use our production server.
-7. Run the following code: `./apollo-ios-cli generate -p "UpliftSecrets/apollo-codegen-config-dev.json" -f`
-8. Build the project and you should be good to go.
+5. Select the `Uplift` schema to use our development server and `Uplift-Prod` to use our production server.
+6. Run the following code: `./apollo-ios-cli generate -p "UpliftSecrets/apollo-codegen-config-dev.json" -f`
+7. Build the project and you should be good to go.
 
 ## Common Issues
 

--- a/Uplift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Uplift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "df308b8b46607675f2b9ec8e569109008f9155ce",
-        "version" : "1.2022062300.1"
+        "revision" : "7ce7be095bc3ed3c98b009532fe2d7698c132614",
+        "version" : "1.2024011601.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "7e28eb75e9970edaba346a3c1eab1f8fc479a04d",
-        "version" : "1.7.1"
+        "revision" : "eedde2151859011a44bb7cb05388deb2bf532644",
+        "version" : "1.9.3"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "be49849dcba96f2b5ee550d4eceb2c0fa27dade4",
-        "version" : "10.22.1"
+        "revision" : "fcf5ced6dae2d43fced2581e673cc3b59bdb8ffa",
+        "version" : "10.23.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "482cfa4e5880f0a29f66ecfd60c5a62af28bd1f0",
-        "version" : "10.22.1"
+        "revision" : "6ec4ca62b00a665fa09b594fab897753a8c635fa",
+        "version" : "10.23.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "ea4cb5cc0c39c732b85386263116d2e2fdbbdc61",
-        "version" : "1.49.2"
+        "revision" : "67043f6389d0e28b38fa02d1c6952afeb04d807f",
+        "version" : "1.62.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "76135c9f4e1ac85459d5fec61b6f76ac47ab3a4c",
-        "version" : "3.3.1"
+        "revision" : "9534039303015a84837090d20fa21cae6e5eadb6",
+        "version" : "3.3.2"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
-        "version" : "0.14.1"
+        "revision" : "e78ae0220e17525a15ac68c697a155eb7a672a8e",
+        "version" : "0.15.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
       }
     },
     {

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -21,7 +21,6 @@ mkdir ../UpliftSecrets
 wget -O ../UpliftSecrets/apollo-codegen-config-dev.json "$CODEGEN_DEV"
 wget -O ../UpliftSecrets/apollo-codegen-config-prod.json "$CODEGEN_PROD"
 wget -O ../UpliftSecrets/Keys.xcconfig "$KEYS"
-wget -O ../UpliftSecrets/schema.graphqls "$SCHEMA"
 wget -O ../UpliftSecrets/GoogleService-Info.plist "$GOOGLE_PLIST"
 
 echo "Generating API file"

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -9,11 +9,6 @@
 echo "Installing Swiftlint via Homebrew"
 brew install swiftlint
 
-echo "Installing Apollo Client Dependencies"
-brew install node
-npm install -g apollo
-npm install -g graphql
-
 echo "Downloading Secrets"
 brew install wget
 cd $CI_PRIMARY_REPOSITORY_PATH/ci_scripts


### PR DESCRIPTION
## Overview

Fix Xcode Cloud issues with Apollo.

## Changes Made

- Update `README.md` by removing instructions regarding Apollo dependency installation.
- Update `ci_post_clone.sh` by removing Apollo dependency installation.
- Update Swift Packages.

## Test Coverage

- Changed the Xcode Cloud workflow to trigger on push to `vin/apollo` to see if the build succeeds.
