### PR TITLE
Remove code generation during the build phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,32 +41,18 @@ fi
 
 ```
 
-- There should also be another run script labeled **Generate API** If not, create a **New Run Script Phase** with the following script:
-
-```bash
-CLI_PATH="./apollo-ios-cli"
-SECRETS_PATH="${SRCROOT}/UpliftSecrets"
-
-if [ "${CONFIGURATION}" != "Release" ]; then
-  CONFIG_PATH="${SECRETS_PATH}/apollo-codegen-config-dev.json"
-fi
-
-if [ "${CONFIGURATION}" = "Release" ]; then
-  CONFIG_PATH="${SECRETS_PATH}/apollo-codegen-config-prod.json"
-fi
-
-"${CLI_PATH}" generate -p "${CONFIG_PATH}" -f
-
-```
-
 5. Select the `Uplift` schema to use our development server and `Uplift-Prod` to use our production server.
-6. Run the following code: `./apollo-ios-cli generate -p "UpliftSecrets/apollo-codegen-config-dev.json" -f`
+6. Generate the Apollo API:
+
+- Dev: `./apollo-ios-cli generate -p "UpliftSecrets/apollo-codegen-config-dev.json" -f`
+- Prod: `./apollo-ios-cli generate -p "UpliftSecrets/apollo-codegen-config-prod.json" -f`
+
 7. Build the project and you should be good to go.
 
 ## Common Issues
 
 - If you are unable to reproduce a new Apollo generated API folder, go to **Project > Package Dependencies** and remove `UpliftAPI`. Then, add a new **Local** package dependency that points to the `UpliftAPI` folder in the project directory.
-- If the build script for generating the API folder doesn't work, you can manually generate the API via `./apollo-ios-cli generate -p "UpliftSecrets/apollo-codegen-config-dev.json" -f`
+- If the API is not working properly, try manually generating the API with the CLI.
 
 ## Codebase Outline
 

--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -481,7 +481,6 @@
 				2E8FE3892B1278B700B3DC6A /* Frameworks */,
 				2E8FE38A2B1278B700B3DC6A /* Resources */,
 				2EF1A2542B1299FB007A299F /* SwiftLint */,
-				2EF1A2552B129A77007A299F /* Generate API */,
 				2E45B2432B4E655D00FB83B7 /* Crashlytics */,
 			);
 			buildRules = (
@@ -628,25 +627,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint >/dev/null; then\n    swiftlint --fix && swiftlint\nelse\n    echo \"ERROR: SwiftLint not installed\"\n    exit 1\nfi\n";
-		};
-		2EF1A2552B129A77007A299F /* Generate API */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 12;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Generate API";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "CLI_PATH=\"./apollo-ios-cli\"\nSECRETS_PATH=\"${SRCROOT}/UpliftSecrets\"\n\nif [ \"${CONFIGURATION}\" != \"Release\" ]; then\n  CONFIG_PATH=\"${SECRETS_PATH}/apollo-codegen-config-dev.json\"\nfi\n\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\n  CONFIG_PATH=\"${SECRETS_PATH}/apollo-codegen-config-prod.json\"\nfi\n\n\"${CLI_PATH}\" generate -p \"${CONFIG_PATH}\" -f\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Overview

Apollo no longer recommends running their code generation as an Xcode build phase. The generated files change whenever we modify our `.graphql` operation definitions. Running the code generation script on every build increases build times and slows development. Code generation should be run manually using the CLI whenever the `.graphql` files are modified.

## Changes Made
- Update README.
- Update Build Phase scripts.