### PR TITLE
Comment out giveaway modal on home

### DIFF
--- a/Uplift/Views/HomeView.swift
+++ b/Uplift/Views/HomeView.swift
@@ -132,7 +132,8 @@ struct HomeView: View {
             VStack(alignment: .leading, spacing: 12) {
                 viewModel.showCapacities ? capacitiesView : nil
 
-                giveawayModalCell
+                // TODO: Uncomment to display giveaway modal
+//                giveawayModalCell
 
                 HStack {
                     Text("GYMS")


### PR DESCRIPTION
## Overview

Commented out the giveaway modal on the home page for future use, since we do not have an active giveaway.

## Screenshots

<!-- use the following for images -->
<details>
  <summary>Home Page</summary>
  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/731ec6d6-f88a-46b6-81b2-5805c30d327f" width="300px" height="auto"></td>
    <td><img src="https://github.com/user-attachments/assets/ea8b7136-7e45-4d07-8ab8-7f896763ae8d" width="300px" height="auto"></td>
  </tr>
 </table>
</details>