### PR TITLE
Fix Tab Bar and Class Detail Navigation

### DIFF
--- a/Uplift/Utils/Constants.swift
+++ b/Uplift/Utils/Constants.swift
@@ -126,6 +126,7 @@ struct Constants {
         static let gymDetailHorizontal: CGFloat = 24
         static let gymDetailSpacing: CGFloat = 20
         static let homeHorizontal: CGFloat = 16
+        static let tabBarHeight: CGFloat = 64
     }
 
     /// Shadows usde in Uplift's design system.

--- a/Uplift/Utils/Constants.swift
+++ b/Uplift/Utils/Constants.swift
@@ -129,7 +129,7 @@ struct Constants {
         static let tabBarHeight: CGFloat = 64
     }
 
-    /// Shadows usde in Uplift's design system.
+    /// Shadows used in Uplift's design system.
     enum Shadows {
         static let normalDark = ShadowConfig(
             color: Constants.Colors.black,

--- a/Uplift/Views/Classes/ClassDetailView.swift
+++ b/Uplift/Views/Classes/ClassDetailView.swift
@@ -13,10 +13,10 @@ struct ClassDetailView: View {
 
     // MARK: - Properties
 
-    let classInstance: FitnessClassInstance
-
-    @ObservedObject var viewModel: ClassesView.ViewModel
+    @State var classInstance: FitnessClassInstance
     @Environment(\.dismiss) private var dismiss
+    private let topViewId: String = "topId"
+    @ObservedObject var viewModel: ClassesView.ViewModel
 
     // MARK: - Constants
 
@@ -38,28 +38,31 @@ struct ClassDetailView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView(.vertical, showsIndicators: false) {
-                scrollContent
-            }
-            .ignoresSafeArea(.all)
-            .padding(.bottom)
-            .navigationBarBackButtonHidden(true)
-            .toolbarBackground(.hidden, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    NavBackButton(dismiss: dismiss)
+            ScrollViewReader { reader in
+                ScrollView(.vertical, showsIndicators: false) {
+                    scrollContent(reader)
                 }
-            }
-            .background(Constants.Colors.white)
-            .onAppear {
-                viewModel.fetchAllClasses()
+                .ignoresSafeArea(.all)
+                .padding(.bottom)
+                .navigationBarBackButtonHidden(true)
+                .toolbarBackground(.hidden, for: .navigationBar)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        NavBackButton(dismiss: dismiss)
+                    }
+                }
+                .background(Constants.Colors.white)
+                .onAppear {
+                    viewModel.fetchAllClasses()
+                }
             }
         }
     }
 
-    private var scrollContent: some View {
+    private func scrollContent(_ reader: ScrollViewProxy) -> some View {
         VStack(spacing: 0) {
             heroSection
+                .id(topViewId)
             dateTimeSection
             DividerLine()
             // TODO: Function data is not in backend
@@ -70,7 +73,7 @@ struct ClassDetailView: View {
 //            DividerLine()
             descriptionSection
             DividerLine()
-            nextSessionsSection
+            nextSessionsSection(reader)
         }
         .padding(.bottom)
     }
@@ -210,7 +213,7 @@ struct ClassDetailView: View {
             .padding(textPadding)
     }
 
-    private var nextSessionsSection: some View {
+    private func nextSessionsSection(_ reader: ScrollViewProxy) -> some View {
         VStack(spacing: 24) {
             Text("NEXT SESSIONS")
                 .font(Constants.Fonts.h2)
@@ -225,8 +228,11 @@ struct ClassDetailView: View {
                     }
                 } else {
                     ForEach(viewModel.nextSessions(classInstance: classInstance), id: \.self) { classInstance in
-                        NavigationLink {
-                            ClassDetailView(classInstance: classInstance, viewModel: viewModel)
+                        Button {
+                            withAnimation {
+                                self.classInstance = classInstance
+                                reader.scrollTo(topViewId)
+                            }
                         } label: {
                             NextSessionCell(classInstance: classInstance, viewModel: viewModel)
                         }

--- a/Uplift/Views/ClassesView.swift
+++ b/Uplift/Views/ClassesView.swift
@@ -64,7 +64,7 @@ struct ClassesView: View {
                 calendarView
                 classesOnDay
             }
-            .padding(.bottom, 32)
+            .padding(.bottom, 32 + Constants.Padding.tabBarHeight)
         }
         .refreshable {
             viewModel.refreshClasses()

--- a/Uplift/Views/HomeView.swift
+++ b/Uplift/Views/HomeView.swift
@@ -174,7 +174,7 @@ struct HomeView: View {
                 EdgeInsets(
                     top: 12,
                     leading: Constants.Padding.homeHorizontal,
-                    bottom: 32,
+                    bottom: 32 + Constants.Padding.tabBarHeight,
                     trailing: Constants.Padding.homeHorizontal
                 )
             )

--- a/Uplift/Views/MainView.swift
+++ b/Uplift/Views/MainView.swift
@@ -29,7 +29,8 @@ struct MainView: View {
                     ClassesView()
                         .environmentObject(tabBarProp)
                 }
-
+            }
+            .overlay(alignment: .bottom) {
                 !tabBarProp.hidden ? tabBar.transition(.move(edge: .bottom)) : nil
             }
 
@@ -75,7 +76,7 @@ struct MainView: View {
 
             Spacer()
         }
-        .frame(height: 64)
+        .frame(height: Constants.Padding.tabBarHeight)
         .background(Constants.Colors.yellow)
         .ignoresSafeArea(.all)
     }


### PR DESCRIPTION
## Overview

Fixed extra offset/spacing with the tab bar and unnecessary navigation with nested class detail pages.

## Changes Made

### MainView

- Modified tab bar to overlay the main pages, fixing the offset that appears when entering the class detail page.

### ClassDetailView

- Removed navigation to new instances of `ClassDetailView`. Modified to update the instance on the current class detail page with the respective class details when clicking the next sessions cell.
- Used `ScrollViewReader` to scroll back to the top of the screen after clicking on a next sessions cell.

### Other Changes

- Added tab bar padding to Constants and applied padding to `HomeView` and `ClassesView`.

## Screenshots

<!-- use the following for videos -->
<details>
  <summary>Fixes</summary>
  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/f9807a27-2408-4c5c-aca8-ab37c35933a4" type="video/mp4"></td>
    <td><video src="https://github.com/user-attachments/assets/96431409-c39a-499d-8131-13acb37412b5" type="video/mp4"></td>
  </tr>
 </table>
</details>
