### PR TITLE
Fixed Teagle capacities bug on gym detail view

### DIFF
--- a/Uplift/Views/Home/GymDetailView.swift
+++ b/Uplift/Views/Home/GymDetailView.swift
@@ -58,11 +58,6 @@ struct GymDetailView: View {
             heroSection
 //            !gym.amenities.isEmpty ? amenitiesSection : nil
             slidingTabBar(gymName: viewModel.determineGymNameEnum(gym: gym))
-                .onTapGesture {
-                    if viewModel.determineGymNameEnum(gym: gym) == .teagle {
-                        viewModel.determineSelectedTab(gym: gym, isTeagleUpSelected: isTeagleUpSelected)
-                    }
-                }
             DividerLine()
 
             Group {

--- a/Uplift/Views/Home/GymDetailView.swift
+++ b/Uplift/Views/Home/GymDetailView.swift
@@ -58,6 +58,11 @@ struct GymDetailView: View {
             heroSection
 //            !gym.amenities.isEmpty ? amenitiesSection : nil
             slidingTabBar(gymName: viewModel.determineGymNameEnum(gym: gym))
+                .onTapGesture {
+                    if viewModel.determineGymNameEnum(gym: gym) == .teagle {
+                        viewModel.determineSelectedTab(gym: gym, isTeagleUpSelected: isTeagleUpSelected)
+                    }
+                }
             DividerLine()
 
             Group {

--- a/Uplift/Views/Supporting/CapacitySemiCircleView.swift
+++ b/Uplift/Views/Supporting/CapacitySemiCircleView.swift
@@ -19,8 +19,26 @@ struct CapacitySemiCircleView: View {
     let status: CapacityStatus?
     let timeUpdated: Date?
 
-    @State private var color: Color = Constants.Colors.open
-    @State private var progress: Double = 0.0
+    private var color: Color {
+        switch status {
+        case .notBusy:
+            return Constants.Colors.open
+        case .slightlyBusy:
+            return Constants.Colors.orange
+        case .veryBusy:
+            return Constants.Colors.red
+        case nil:
+            return Constants.Colors.open
+        }
+    }
+    private var progress: Double {
+        switch status {
+        case .notBusy(let double), .slightlyBusy(let double), .veryBusy(let double):
+            return double
+        case nil:
+            return 0
+        }
+    }
 
     // MARK: - UI
 
@@ -93,21 +111,21 @@ struct CapacitySemiCircleView: View {
             }
         }
         .padding(lineWidth / 2)
-        .onAppear {
-            switch status {
-            case .notBusy(let double):
-                color = Constants.Colors.open
-                progress = double
-            case .slightlyBusy(let double):
-                color = Constants.Colors.orange
-                progress = double
-            case .veryBusy(let double):
-                color = Constants.Colors.red
-                progress = double
-            case nil:
-                break
-            }
-        }
+//        .onAppear {
+//            switch status {
+//            case .notBusy(let double):
+//                color = Constants.Colors.open
+//                progress = double
+//            case .slightlyBusy(let double):
+//                color = Constants.Colors.orange
+//                progress = double
+//            case .veryBusy(let double):
+//                color = Constants.Colors.red
+//                progress = double
+//            case nil:
+//                break
+//            }
+//        }
     }
 
 }

--- a/Uplift/Views/Supporting/CapacitySemiCircleView.swift
+++ b/Uplift/Views/Supporting/CapacitySemiCircleView.swift
@@ -27,7 +27,7 @@ struct CapacitySemiCircleView: View {
             return Constants.Colors.orange
         case .veryBusy:
             return Constants.Colors.red
-        case nil:
+        default:
             return Constants.Colors.open
         }
     }
@@ -35,7 +35,7 @@ struct CapacitySemiCircleView: View {
         switch status {
         case .notBusy(let double), .slightlyBusy(let double), .veryBusy(let double):
             return double
-        case nil:
+        default:
             return 0
         }
     }
@@ -111,21 +111,6 @@ struct CapacitySemiCircleView: View {
             }
         }
         .padding(lineWidth / 2)
-//        .onAppear {
-//            switch status {
-//            case .notBusy(let double):
-//                color = Constants.Colors.open
-//                progress = double
-//            case .slightlyBusy(let double):
-//                color = Constants.Colors.orange
-//                progress = double
-//            case .veryBusy(let double):
-//                color = Constants.Colors.red
-//                progress = double
-//            case nil:
-//                break
-//            }
-//        }
     }
 
 }


### PR DESCRIPTION
## Overview

The capacity semicircle would default to show one of the Teagle's capacities (either Up or Down), and wouldn't change when clicking on each tab. Now, they should display the correct capacities corresponding to Teagle Up and Teagle Down.

## Changes Made

- Changed `color` and `progress` on the capacity semicircle to computed properties.

## Screenshots

<!-- use the following for videos -->
  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/d265c007-8e73-42b6-b671-1a71197bf79e" type="video/mp4"></td>
    <td><video src="https://github.com/user-attachments/assets/b9e6d5c2-83e0-40a8-befe-8d1ab625b576" type="video/mp4"></td>
  </tr>
 </table>
