### PR TITLE
Allow non-Cornell emails for app review

### DIFF
--- a/Uplift/Configs/UpliftEnvironment.swift
+++ b/Uplift/Configs/UpliftEnvironment.swift
@@ -18,6 +18,7 @@ enum UpliftEnvironment {
 #else
         static let baseURL: String = "UPLIFT_PROD_URL"
 #endif
+        static let appReviewAllowedEmails = "APP_REVIEW_ALLOWED_EMAILS"
         static let announcementsCommonPath = "ANNOUNCEMENTS_COMMON_PATH"
         static let announcementsHost = "ANNOUNCEMENTS_HOST"
         static let announcementsPath = "ANNOUNCEMENTS_PATH"
@@ -88,6 +89,17 @@ enum UpliftEnvironment {
             fatalError("ANNOUNCEMENTS_SCHEME not found in Info.plist")
         }
         return value
+    }()
+
+    /// List of non-Cornell emails allowed for app review sign-in.
+    static let appReviewAllowedEmails: Set<String> = {
+        let value = (UpliftEnvironment.infoDict[Keys.appReviewAllowedEmails] as? String) ?? ""
+        return Set(
+            value
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                .filter { !$0.isEmpty }
+        )
     }()
 
 }

--- a/Uplift/Info.plist
+++ b/Uplift/Info.plist
@@ -12,6 +12,8 @@
 	<string>$(ANNOUNCEMENTS_PATH)</string>
 	<key>ANNOUNCEMENTS_SCHEME</key>
 	<string>$(ANNOUNCEMENTS_SCHEME)</string>
+	<key>APP_REVIEW_ALLOWED_EMAILS</key>
+	<string>uplift.appdev.test@gmail.com</string>
 	<key>CFBundleGetInfoString</key>
 	<array>
 		<dict>

--- a/Uplift/ViewModels/LoginViewModel.swift
+++ b/Uplift/ViewModels/LoginViewModel.swift
@@ -17,6 +17,7 @@ class LoginViewModel: ObservableObject {
     @Published var didPresentError: Bool = false
     @Published var errorText: String = ""
     private let signInConfig = GIDConfiguration.init(clientID: UpliftEnvironment.Keys.googleClientID)
+    private let cornellDomain = "@cornell.edu"
 
     // MARK: - Functions
 
@@ -28,19 +29,36 @@ class LoginViewModel: ObservableObject {
             with: signInConfig,
             presenting: presentingViewController
         ) { [weak self] user, error in
+            guard let self else { return }
             guard error == nil else { return }
             guard let email = user?.profile?.email else { return }
 
-            if !email.contains("@cornell.edu") {
+            if !isValidEmail(email) {
                 GIDSignIn.sharedInstance.signOut()
-                self?.didPresentError = true
-                self?.errorText = "Please sign in with a Cornell email"
+                self.didPresentError = true
+                self.errorText = "Please sign in with a Cornell email or approved reviewer account"
                 return
             }
 
             guard let fullName = user?.profile?.name else { return }
-            let netID = email.replacingOccurrences(of: "@cornell.edu", with: "")
+            let netID = netID(from: email)
+
             success(email, fullName, netID)
         }
+    }
+
+    /// Returns whether the email is a Cornell email or one of the app review allowed emails.
+    private func isValidEmail(_ email: String) -> Bool {
+        email.hasSuffix(cornellDomain) || UpliftEnvironment.appReviewAllowedEmails.contains(email)
+    }
+
+    /// Returns the Cornell NetID from the email. If it's a non-Cornell email, returns the email prefix.
+    private func netID(from email: String) -> String {
+        if email.hasSuffix(cornellDomain) {
+            return email.replacingOccurrences(of: cornellDomain, with: "")
+        }
+
+        // For non-Cornell accounts, just use the email prefix
+        return email.split(separator: "@").first.map(String.init) ?? email
     }
 }


### PR DESCRIPTION
## Overview

Modified restriction for google sign in to allow non-Cornell emails for app review testers by creating an allow list. Created a test email `uplift.appdev.test@gmail.com`, which will be given for app review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced login validation to support approved reviewer accounts in addition to Cornell email accounts
  * App now recognizes configured reviewer email addresses for authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->