### PR TITLE
Bug fix: Disabled distance label when location is off

### DIFF
--- a/Uplift/Views/Home/HomeGymCell.swift
+++ b/Uplift/Views/Home/HomeGymCell.swift
@@ -15,7 +15,7 @@ struct HomeGymCell: View {
 
     let gym: Gym
 
-    @State private var distance: String = "0.0"
+    @State private var distance: String = ""
 
     // MARK: - Constants
 
@@ -49,10 +49,14 @@ struct HomeGymCell: View {
                 .stroke(Constants.Colors.gray01, lineWidth: 1)
                 .upliftShadow(Constants.Shadows.smallLight)
         )
-        .onChange(of: LocationManager.shared.userLocation) { _ in
-            distance = LocationManager.shared.distanceToCoordinates(
-                latitude: gym.latitude, longitude: gym.longitude
-            )
+        .onChange(of: LocationManager.shared.userLocation) { location in
+            if location == nil {
+                distance = ""
+            } else {
+                distance = LocationManager.shared.distanceToCoordinates(
+                    latitude: gym.latitude, longitude: gym.longitude
+                )
+            }
         }
     }
 
@@ -194,7 +198,7 @@ struct HomeGymCell: View {
     }
 
     private var distanceText: some View {
-        Text("\(distance)mi")
+        Text(distance.isEmpty ? "" : "\(distance)mi")
             .font(Constants.Fonts.labelMedium)
             .foregroundStyle(Constants.Colors.gray03)
     }


### PR DESCRIPTION
## Overview

When the location is not allowed or turned off, the gym cells no longer show the 0.0mi label.

## Related PRs or Issues

#164 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced distance information display to conditionally render based on location availability. Distance is now shown in miles when user location is accessible and hidden when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->