### PR TITLE
Fix crash in Popular Times for facilities that close after midnight

### DIFF
--- a/Uplift/ViewModels/FitnessCenterViewModel.swift
+++ b/Uplift/ViewModels/FitnessCenterViewModel.swift
@@ -127,6 +127,11 @@ extension FitnessCenterView {
                 endHour += 1
             }
 
+            if endHour <= startHour {
+                endHour += 24
+            }
+            let closesAfterMidnight = endHour >= 24
+
             let filteredCapacities = capacities.filter { $0.dayOfWeek.capitalized == today.dayOfWeekComplete() }
 
             let hourRange = startHour...endHour
@@ -136,9 +141,17 @@ extension FitnessCenterView {
             }
 
             filteredCapacities.forEach { capacity in
-                if hourRange.contains(capacity.hourOfDay) {
-                    if let index = finalHourlyCapacities.firstIndex(where: { $0.hourOfDay == capacity.hourOfDay }) {
-                        finalHourlyCapacities[index] = capacity
+                let normalizedHour = (closesAfterMidnight && capacity.hourOfDay < startHour)
+                    ? capacity.hourOfDay + 24
+                    : capacity.hourOfDay
+
+                if hourRange.contains(normalizedHour) {
+                    if let index = finalHourlyCapacities.firstIndex(where: { $0.hourOfDay == normalizedHour }) {
+                        finalHourlyCapacities[index] = HourlyAverageCapacity(
+                            averagePercent: capacity.averagePercent,
+                            dayOfWeek: capacity.dayOfWeek,
+                            hourOfDay: normalizedHour
+                        )
                     }
                 }
 


### PR DESCRIPTION
## Problem
`filterCapacities` built its hour range as `startHour...endHour` using only the hour component of the day's open/close times. When a facility closes after midnight (ex: 6 AM – 1 AM), the backend stores the closing time on the next calendar day, so its hour component (`1`) is less than the opening hour (`6`). Constructing `6...1` is a fatal `ClosedRange` precondition failure that crashed the app whenever such a facility's Popular Times were loaded.

## Fix
- Extend `endHour` past 24 when the facility closes after midnight so the range stays valid.
- Shift post-midnight capacities (0–23) into the extended range so they map to the correct chart slots and render in chronological order after 11 PM.

## Testing
`xcodebuild -scheme Uplift` → **BUILD SUCCEEDED**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fitness center capacity filtering for facilities that close after midnight.
  * Corrected post-midnight capacity times so hourly availability displays accurately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->